### PR TITLE
feat: Add Telegram folder invite link support (v0.5.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0] - 2025-10-07
+
+### Added
+- **Telegram folder invite link support** - Automatically expand folder links to channel lists
+- `extract_folder_slug()` method to parse `t.me/addlist/` URLs
+- `get_channels_from_folder()` method to resolve folders via Telethon API
+- `has_folder_links()` helper in Config to detect folder URLs
+- Support for both `ChatlistInvite` and `ChatlistInviteAlready` response types
+- Folder links work in `channels.yaml`, CLI arguments, and channel groups
+
+### Improved
+- Automatic duplicate removal when expanding multiple folder links
+- Clear console feedback when expanding folders (channel count and names)
+- Error handling for invalid folder URLs or access issues
+- Support for mixing regular channels and folder links
+
+### Documentation
+- Updated `channels.yaml.example` with folder link examples
+- Added folder link usage to README.md
+- Documented folder link feature in Copilot instructions
+
 ## [0.4.0] - 2025-10-07
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -74,16 +74,22 @@ channels:
   - "@ai_news"
   - "@ml_research"
   - "@your_channel"
+  # Or use Telegram folder invite links
+  - "https://t.me/addlist/YourFolderSlug"
 
 groups:
   news:
     - "@ai_news"
     - "@tech_digest"
+    # Folder links work in groups too
+    - "https://t.me/addlist/NewsChannelsFolder"
   
   research:
     - "@ml_research"
     - "@arxiv_daily"
 ```
+
+**Note:** You can use Telegram folder invite links (e.g., `https://t.me/addlist/Wv30yLzHEuw4YTky`) to automatically include all channels from a shared folder. This is useful for managing large channel collections.
 
 ## Usage
 
@@ -104,6 +110,18 @@ python -m src.main --group research
 
 ```bash
 python -m src.main --channels @ai_news @ml_research @deeplearning
+```
+
+You can also use folder links directly in CLI:
+
+```bash
+python -m src.main --channels "https://t.me/addlist/Wv30yLzHEuw4YTky"
+```
+
+Or mix channels and folder links:
+
+```bash
+python -m src.main --channels @ai_news "https://t.me/addlist/FolderSlug" @ml_research
 ```
 
 ### Specify Channels and Dates

--- a/channels.yaml.example
+++ b/channels.yaml.example
@@ -4,6 +4,8 @@
 # List of Telegram channels to fetch posts from
 # Use @ for public channels (e.g., @ai_news)
 # Use channel ID for private channels (e.g., -1001234567890)
+# You can also use Telegram folder invite links (e.g., https://t.me/addlist/SLUG)
+# Folder links will be automatically expanded to include all channels in that folder
 
 channels:
   # ML/AI News and Research
@@ -13,17 +15,27 @@ channels:
   - "@deep_school"
   - "@seeallochnaya"
   
+  # Or use a folder link to automatically include all channels from a folder
+  # - "https://t.me/addlist/Wv30yLzHEuw4YTky"
+  
+  # You can mix regular channels and folder links
+  # - "@my_channel"
+  # - "https://t.me/addlist/AnotherFolderSlug"
+  
   # Add more channels here
   # - "@your_channel"
   # - "@another_channel"
 
 # Optional: Define channel groups for better organization
 # When using groups, you can specify which group to use via --group argument
+# Groups also support folder links
 groups:
   news:
     - "@ai_news"
     - "@ml_news"
     - "@tech_digest"
+    # Folder links work in groups too
+    # - "https://t.me/addlist/NewsChannelsFolder"
   
   research:
     - "@ml_research"

--- a/src/config.py
+++ b/src/config.py
@@ -141,6 +141,22 @@ class Config:
         return channels
 
     @classmethod
+    def has_folder_links(cls, channels: List[str]) -> bool:
+        """
+        Check if channel list contains any folder links.
+        
+        Args:
+            channels: List of channels (may include folder URLs)
+            
+        Returns:
+            True if any folder links found
+        """
+        for item in channels:
+            if isinstance(item, str) and 't.me/addlist/' in item:
+                return True
+        return False
+
+    @classmethod
     def get_default_settings(cls, config_path: str = "channels.yaml") -> Dict[str, Any]:
         """
         Get default settings from YAML configuration.

--- a/src/main.py
+++ b/src/main.py
@@ -180,6 +180,27 @@ async def main_async():
             user_info = await fetcher.get_user_info()
             print(f"Authenticated as: {user_info['first_name']} (@{user_info['username']})")
 
+            # Check if channels list contains folder links
+            if Config.has_folder_links(channels):
+                print("\n🔄 Detected folder links, expanding...")
+                expanded_channels = []
+                for item in channels:
+                    if 't.me/addlist/' in item:
+                        # This is a folder link
+                        print(f"   Expanding folder: {item}")
+                        try:
+                            folder_channels = await fetcher.get_channels_from_folder(item)
+                            expanded_channels.extend(folder_channels)
+                        except Exception as e:
+                            print(f"   ⚠️  Failed to expand folder {item}: {e}")
+                    else:
+                        # Regular channel
+                        expanded_channels.append(item)
+                
+                # Remove duplicates while preserving order
+                channels = list(dict.fromkeys(expanded_channels))
+                print(f"\n✅ Expanded to {len(channels)} channels: {', '.join(channels)}\n")
+
             messages = await fetcher.fetch_messages(channels, start_date, end_date)
 
             print(f"\n✅ Fetched {len(messages)} messages total\n")


### PR DESCRIPTION
- Add extract_folder_slug() and get_channels_from_folder() to TelegramFetcher
- Handle both ChatlistInvite and ChatlistInviteAlready response types
- Add has_folder_links() helper to Config class
- Integrate folder expansion in main.py workflow
- Update channels.yaml.example with folder link examples
- Update README.md and CHANGELOG.md with folder link documentation

Folder links (t.me/addlist/SLUG) can now be used in:
- channels.yaml
- CLI --channels arguments
- Channel groups