### PR TITLE
feat: Add automated daily digest generation via cron

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -146,5 +146,11 @@ cython_debug/
 digest_*.txt
 output/
 
+# Cron logs
+cron.log
+
+# User-specific scripts
+run_digest.sh
+
 # Other
 PROJECT_STATUS.md

--- a/CRON_SETUP.md
+++ b/CRON_SETUP.md
@@ -1,0 +1,170 @@
+# Cron Setup for Telegram Digest
+
+## Automated Daily Digest Generation
+
+The project is configured to automatically generate and send digests every day at 22:00 (10 PM).
+
+## Setup Details
+
+### Script: `run_digest.sh`
+
+First, create your script from the example:
+
+```bash
+cp run_digest.sh.example run_digest.sh
+```
+
+Edit `run_digest.sh` and update the `PROJECT_DIR` variable with your actual project path:
+
+```bash
+PROJECT_DIR="/Users/yourusername/path/to/telegram-digest"
+```
+
+Make the script executable:
+
+```bash
+chmod +x run_digest.sh
+```
+
+The script:
+1. Navigates to project directory
+2. Activates Python virtual environment
+3. Runs digest generation with `--send-to-telegram` flag
+4. Deactivates venv
+
+### Cron Job
+
+Add to crontab (replace paths with your actual paths):
+
+```bash
+0 22 * * * /path/to/telegram-digest/run_digest.sh >> /path/to/telegram-digest/cron.log 2>&1
+```
+
+**Schedule:** Daily at 22:00 (10 PM)
+
+**Logging:** All output (stdout and stderr) is logged to `cron.log`
+
+## Management Commands
+
+### View Current Cron Jobs
+```bash
+crontab -l
+```
+
+### Edit Cron Jobs
+```bash
+crontab -e
+```
+
+### Remove All Cron Jobs
+```bash
+crontab -r
+```
+
+### Remove Specific Job
+```bash
+crontab -e
+# Delete the line with run_digest.sh and save
+```
+
+## View Logs
+
+```bash
+tail -f /Users/sserov/Documents/PROJECTS/telegram-digest/cron.log
+```
+
+Or view recent logs:
+```bash
+tail -n 50 /Users/sserov/Documents/PROJECTS/telegram-digest/cron.log
+```
+
+## Testing
+
+Test the script manually before relying on cron:
+
+```bash
+/Users/sserov/Documents/PROJECTS/telegram-digest/run_digest.sh
+```
+
+## Troubleshooting
+
+### Cron Not Running
+
+1. **Check cron service is running (macOS):**
+   ```bash
+   sudo launchctl list | grep cron
+   ```
+
+2. **Grant Full Disk Access to cron:**
+   - System Preferences → Security & Privacy → Privacy → Full Disk Access
+   - Add `/usr/sbin/cron`
+
+3. **Check cron logs:**
+   ```bash
+   log show --predicate 'process == "cron"' --last 1h
+   ```
+
+### Script Fails in Cron
+
+1. **Use absolute paths** - Already configured in `run_digest.sh`
+2. **Check environment variables** - Ensure `.env` file exists and is readable
+3. **Verify PROJECT_DIR** - Make sure the path in `run_digest.sh` is correct
+4. **Check permissions:**
+   ```bash
+   ls -la run_digest.sh
+   ```
+
+### No Digest Sent
+
+1. **Check logs:**
+   ```bash
+   cat cron.log
+   ```
+
+2. **Verify Telegram bot token:**
+   ```bash
+   grep TELEGRAM_BOT_TOKEN .env
+   ```
+
+3. **Check OUTPUT_TELEGRAM_CHANNEL in .env**
+
+4. **Test manually:**
+   ```bash
+   ./run_digest.sh
+   # or
+   python -m src.main --send-to-telegram
+   ```
+
+## Changing Schedule
+
+To change the execution time, edit crontab:
+
+```bash
+crontab -e
+```
+
+Cron format:
+```
+* * * * * command
+│ │ │ │ │
+│ │ │ │ └─── Day of week (0-7, Sunday = 0 or 7)
+│ │ │ └───── Month (1-12)
+│ │ └─────── Day of month (1-31)
+│ └───────── Hour (0-23)
+└─────────── Minute (0-59)
+```
+
+Examples:
+- `0 9 * * *` - Every day at 9:00 AM
+- `0 22 * * *` - Every day at 10:00 PM (current)
+- `0 18 * * 1-5` - Weekdays at 6:00 PM
+- `0 12 * * 0` - Every Sunday at noon
+
+## Alternative: launchd (macOS Recommended)
+
+For macOS, launchd is more reliable than cron. To migrate:
+
+1. Create plist file: `~/Library/LaunchAgents/com.sserov.telegram-digest.plist`
+2. Use `launchctl load/unload` to manage
+
+See macOS documentation for details.

--- a/README.md
+++ b/README.md
@@ -9,12 +9,14 @@ This project collects posts from specified Telegram channels over a defined peri
 ## Features
 
 - 📥 Collect posts from multiple Telegram channels
-- 📅 Filter posts by date (can specify a date range)
+- � Support for Telegram folder invite links (automatic channel expansion)
+- �📅 Filter posts by date (can specify a date range)
 - 🤖 Generate structured digests using Cerebras AI
 - 📊 Automatic grouping by categories with importance-based sorting
 - 💾 Save digest to text file
 - 📤 Send digest to Telegram via Bot API (HTML formatting)
 - 🔄 Map-reduce processing for large data volumes
+- ⏰ Automated daily generation via cron/scheduler
 
 ## Requirements
 
@@ -164,6 +166,45 @@ Note: Digest is formatted using HTML markup (bold, links, blockquotes).
 ```bash
 python -m src.main --help
 ```
+
+## Automated Daily Generation
+
+You can set up automatic daily digest generation using cron:
+
+### Quick Setup
+
+1. Create your script from the example:
+   ```bash
+   cp run_digest.sh.example run_digest.sh
+   ```
+
+2. Edit `run_digest.sh` and update the `PROJECT_DIR` variable:
+   ```bash
+   PROJECT_DIR="/Users/yourusername/path/to/telegram-digest"
+   ```
+
+3. Make executable and test:
+   ```bash
+   chmod +x run_digest.sh
+   ./run_digest.sh
+   ```
+
+4. Set up daily execution at 22:00 (10 PM):
+   ```bash
+   (crontab -l 2>/dev/null; echo "0 22 * * * /path/to/telegram-digest/run_digest.sh >> /path/to/telegram-digest/cron.log 2>&1") | crontab -
+   ```
+
+5. Verify cron job:
+   ```bash
+   crontab -l
+   ```
+
+6. Check logs:
+   ```bash
+   tail -f cron.log
+   ```
+
+For detailed setup instructions, troubleshooting, and alternative schedules, see [CRON_SETUP.md](CRON_SETUP.md).
 
 ## Configuration
 

--- a/run_digest.sh.example
+++ b/run_digest.sh.example
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# Telegram Digest Daily Runner
+# This script activates venv and runs digest generation
+#
+# SETUP:
+# 1. Copy this file: cp run_digest.sh.example run_digest.sh
+# 2. Edit run_digest.sh and replace PROJECT_DIR with your actual path
+# 3. Make executable: chmod +x run_digest.sh
+# 4. Test: ./run_digest.sh
+# 5. Add to cron: crontab -e
+#    0 22 * * * /path/to/run_digest.sh >> /path/to/cron.log 2>&1
+
+# Navigate to project directory
+# CHANGE THIS to your actual project path:
+PROJECT_DIR="/path/to/telegram-digest"
+cd "$PROJECT_DIR"
+
+# Activate virtual environment
+source venv/bin/activate
+
+# Run digest generation and send to Telegram
+python -m src.main --send-to-telegram
+
+# Deactivate venv (optional, as script will exit anyway)
+deactivate


### PR DESCRIPTION
- Add run_digest.sh.example template for users
- Add CRON_SETUP.md with detailed setup instructions
- Update README.md with quick setup guide
- Add run_digest.sh and cron.log to .gitignore

Users can now set up automatic daily digest generation at 22:00 using cron. The example script provides a template that users can customize with their paths.